### PR TITLE
Fixes error where Content-Type didn't have an encoding defined

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches:
     - main
+    tags:
+      - *
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Public Hemoglobin
+
+env:
+  name: hemoglobin
+  command: hemoglobin
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  publish:
+      name: Publish to PyPI
+      runs-on: ubuntu-latest
+      needs:
+          - test
+          - lint
+      steps:
+        - uses: actions/checkout@v2
+        - name: Set up Python ${{ matrix.python-version }}
+          uses: actions/setup-python@v2
+          with:
+            python-version: ${{ matrix.python-version }}
+        - name: Publish to PyPI
+          run: |
+            python3 -m pip install setuptools==50.1.0 twine==3.2.0 wheel==0.35.1
+            python3 setup.py sdist
+            python3 -m twine check dist/*
+            python3 -m twine upload -u "__token__" -p "${{ secrets.PYPI_API }}" dist/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,10 @@
-name: Python3
+name: Test Hemoglobin
 
 env:
   name: hemoglobin
   command: hemoglobin
 
-on:
-  push:
-    branches:
-    - master
+on: push
 
 jobs:
   lint:
@@ -53,21 +50,3 @@ jobs:
           python3 -m unittest discover tests
           python3 -m ${{ env.name }} --help
           python3 -m ${{ env.name }} "${{secrets.GRAMMARBOT_APIKEY}}" samples/example.txt
-  publish:
-      name: Publish to PyPI
-      runs-on: ubuntu-latest
-      needs:
-          - test
-          - lint
-      steps:
-        - uses: actions/checkout@v2
-        - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v2
-          with:
-            python-version: ${{ matrix.python-version }}
-        - name: Publish to PyPI
-          run: |
-            python3 -m pip install setuptools==50.1.0 twine==3.2.0 wheel==0.35.1
-            python3 setup.py sdist
-            python3 -m twine check dist/*
-            python3 -m twine upload -u "__token__" -p "${{ secrets.PYPI_API }}" dist/*

--- a/hemoglobin/grammarbot.py
+++ b/hemoglobin/grammarbot.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from typing import List
 
+import mimeparse
 import requests
 
 from grammarbot import GrammarBotClient, GrammarBotApiResponse, GrammarBotMatch
@@ -55,7 +56,7 @@ class HemoglobinGrammarBot(GrammarBotClient):
         return requests.get(self._endpoint, params=params)
 
     def parse_response(self, response):
-        mime_type, _ = response.headers["Content-Type"].split(";")
+        mime_type, _, _ = mimeparse.parse_mime_type(response.headers["Content-Type"])
         if mime_type == "application/json":
             json = response.json()
             return self.API_RESPONSE(json)

--- a/hemoglobin/grammarbot.py
+++ b/hemoglobin/grammarbot.py
@@ -56,8 +56,8 @@ class HemoglobinGrammarBot(GrammarBotClient):
         return requests.get(self._endpoint, params=params)
 
     def parse_response(self, response):
-        mime_type, _, _ = mimeparse.parse_mime_type(response.headers["Content-Type"])
-        if mime_type == "application/json":
+        main_mime_type, sub_mime_type, _ = mimeparse.parse_mime_type(response.headers["Content-Type"])
+        if main_mime_type == "application" and sub_mime_type == "json":
             json = response.json()
             return self.API_RESPONSE(json)
         raise GrammarBotException(response.text)

--- a/hemoglobin/grammarbot.py
+++ b/hemoglobin/grammarbot.py
@@ -50,16 +50,21 @@ class HemoglobinGrammarBot(GrammarBotClient):
     def _create_params(self, text):
         return {"language": self.language.value, "text": text, "api_key": self._api_key}
 
+    def get_response(self, text: str):
+        params = self._create_params(text)
+        return requests.get(self._endpoint, params=params)
+
+    def parse_response(self, response):
+        mime_type, _ = response.headers["Content-Type"].split(";")
+        if mime_type == "application/json":
+            json = response.json()
+            return self.API_RESPONSE(json)
+        raise GrammarBotException(response.text)
+
     def check(self, text: str):
         """
         Check a given piece of text for grammatical errors.
         :param text:
             Text to be checked using the API.
         """
-        params = self._create_params(text)
-        response = requests.get(self._endpoint, params=params)
-        mime_type, _ = response.headers["Content-Type"].split(";")
-        if mime_type == "application/json":
-            json = response.json()
-            return self.API_RESPONSE(json)
-        raise GrammarBotException(response.text)
+        return self.parse_response(self.get_response(text))

--- a/hemoglobin/grammarbot.py
+++ b/hemoglobin/grammarbot.py
@@ -56,7 +56,9 @@ class HemoglobinGrammarBot(GrammarBotClient):
         return requests.get(self._endpoint, params=params)
 
     def parse_response(self, response):
-        main_mime_type, sub_mime_type, _ = mimeparse.parse_mime_type(response.headers["Content-Type"])
+        main_mime_type, sub_mime_type, _ = mimeparse.parse_mime_type(
+            response.headers["Content-Type"]
+        )
         if main_mime_type == "application" and sub_mime_type == "json":
             json = response.json()
             return self.API_RESPONSE(json)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 grammarbot==0.2.0
+python-mimeparse==1.6.0 

--- a/tests/test_grammarbot.py
+++ b/tests/test_grammarbot.py
@@ -56,9 +56,10 @@ class TestGrammarBotClient(unittest.TestCase):
             result,
         )
 
-    def test_parse_response_correct_content_type_with_mime_parts(self):
+    def test_parse_response_correct_content_type_with_encoding_part(self):
         class MockResponse:
             headers = {"Content-Type": "application/json; charset=UTF-8"}
+            json = Mock()
 
         class MockApiResponse:
             def __init__(self, json):
@@ -69,10 +70,12 @@ class TestGrammarBotClient(unittest.TestCase):
         result = self.test_hemoglobingrammarbot.parse_response(MockResponse)
 
         self.assertIsInstance(result, MockApiResponse)
+        MockResponse.json.assert_called()
 
-    def test_parse_response_correct_content_type_without_mime_parts(self):
+    def test_parse_response_correct_content_type_without_encoding_part(self):
         class MockResponse:
             headers = {"Content-Type": "application/json"}
+            json = Mock()
 
         class MockApiResponse:
             def __init__(self, json):
@@ -83,3 +86,4 @@ class TestGrammarBotClient(unittest.TestCase):
         result = self.test_hemoglobingrammarbot.parse_response(MockResponse)
 
         self.assertIsInstance(result, MockApiResponse)
+        MockResponse.json.assert_called()

--- a/tests/test_grammarbot.py
+++ b/tests/test_grammarbot.py
@@ -58,7 +58,7 @@ class TestGrammarBotClient(unittest.TestCase):
 
     def test_parse_response_correct_content_type_with_mime_parts(self):
         class MockResponse:
-            headers = "application/json; charset=UTF-8"
+            headers = {"Content-Type": "application/json; charset=UTF-8"}
 
         class MockApiResponse:
             def __init__(self, json):
@@ -72,7 +72,7 @@ class TestGrammarBotClient(unittest.TestCase):
 
     def test_parse_response_correct_content_type_without_mime_parts(self):
         class MockResponse:
-            headers = "application/json"
+            headers = {"Content-Type": "application/json"}
 
         class MockApiResponse:
             def __init__(self, json):

--- a/tests/test_grammarbot.py
+++ b/tests/test_grammarbot.py
@@ -34,22 +34,52 @@ class TestGrammarBotApiResponse(unittest.TestCase):
 
 
 class TestGrammarBotClient(unittest.TestCase):
-    def test_create_params(self):
-        test_text = "test text"
-        test_apikey = "test api_key"
-        test_language = Languages.EN_US
+    def setUp(self):
+        self.test_text = "test text"
+        self.test_apikey = "test api_key"
+        self.test_language = Languages.EN_US
 
-        test_hemoglobingrammarbot = GrammarBotClient(
-            api_key=test_apikey, language=test_language
+        self.test_hemoglobingrammarbot = GrammarBotClient(
+            api_key=self.test_apikey, language=self.test_language
         )
 
-        result = test_hemoglobingrammarbot._create_params(test_text)
+    def test_create_params(self):
+
+        result = self.test_hemoglobingrammarbot._create_params(self.test_text)
 
         self.assertEqual(
             {
-                "language": test_language.value,
-                "text": test_text,
-                "api_key": test_apikey,
+                "language": self.test_language.value,
+                "text": self.test_text,
+                "api_key": self.test_apikey,
             },
             result,
         )
+
+    def test_parse_response_correct_content_type_with_mime_parts(self):
+        class MockResponse:
+            headers = "application/json; charset=UTF-8"
+
+        class MockApiResponse:
+            def __init__(self, json):
+                self.json = json
+
+        self.test_hemoglobingrammarbot.API_RESPONSE = MockApiResponse
+
+        result = self.test_hemoglobingrammarbot.parse_response(MockResponse)
+
+        self.assertIsInstance(result, MockApiResponse)
+
+    def test_parse_response_correct_content_type_without_mime_parts(self):
+        class MockResponse:
+            headers = "application/json"
+
+        class MockApiResponse:
+            def __init__(self, json):
+                self.json = json
+
+        self.test_hemoglobingrammarbot.API_RESPONSE = MockApiResponse
+
+        result = self.test_hemoglobingrammarbot.parse_response(MockResponse)
+
+        self.assertIsInstance(result, MockApiResponse)


### PR DESCRIPTION
* uses fixed version of [python-mimeparse](https://github.com/dbtsai/python-mimeparse) which was last updated in 2016, but should it really change that much?
* Adds tests for both successful and previously failing cases

See example of error here:
https://github.com/yamatt/blog/runs/3310757215?check_suite_focus=true#step:5:2265

```python3
   File "/opt/hostedtoolcache/Python/3.7.11/x64/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/hostedtoolcache/Python/3.7.11/x64/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/opt/hostedtoolcache/Python/3.7.11/x64/lib/python3.7/site-packages/hemoglobin/__main__.py", line 63, in <module>
    render_human(hemoglobin)
  File "/opt/hostedtoolcache/Python/3.7.11/x64/lib/python3.7/site-packages/hemoglobin/__main__.py", line 41, in render_human
    for match in grammarbot_file.matches:
  File "/opt/hostedtoolcache/Python/3.7.11/x64/lib/python3.7/site-packages/hemoglobin/files.py", line 47, in matches
    return self.response.matches
  File "/opt/hostedtoolcache/Python/3.7.11/x64/lib/python3.7/site-packages/hemoglobin/files.py", line 42, in response
    self._response = self.get_grammarbot_response()
  File "/opt/hostedtoolcache/Python/3.7.11/x64/lib/python3.7/site-packages/hemoglobin/files.py", line 50, in get_grammarbot_response
    return self.hemoglobin.grammarbot.check(self.text)
  File "/opt/hostedtoolcache/Python/3.7.11/x64/lib/python3.7/site-packages/hemoglobin/grammarbot.py", line 61, in check
    mime_type, _ = response.headers["Content-Type"].split(";")
ValueError: not enough values to unpack (expected 2, got 1)
```